### PR TITLE
docs: Add OtherModelXXX parameters to API docs. (#1126)

### DIFF
--- a/docs/source/api/pywr.parameters.rst
+++ b/docs/source/api/pywr.parameters.rst
@@ -149,6 +149,16 @@ Hydropower parameters
 
    HydropowerTargetParameter
 
+Multi-model coupling parameters
+-------------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+    OtherModelParameterValueParameter
+    OtherModelNodeFlowParameter
+    OtherModelNodeStorageParameter
+    OtherModelIndexParameterValueIndexParameter
 
 Other parameters
 ----------------

--- a/pywr/parameters/parameters.py
+++ b/pywr/parameters/parameters.py
@@ -74,7 +74,12 @@ from .control_curves import (
     ControlCurvePiecewiseInterpolatedParameter,
     WeightedAverageProfileParameter,
 )
-from . import multi_model_parameters
+from .multi_model_parameters import (
+    OtherModelParameterValueParameter,
+    OtherModelNodeFlowParameter,
+    OtherModelNodeStorageParameter,
+    OtherModelIndexParameterValueIndexParameter,
+)
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.integrate import quad


### PR DESCRIPTION
This also fixes the import in `pywr.parameters` so they are in the main namespace.